### PR TITLE
fix: client types and service methods into server

### DIFF
--- a/packages/client/src/MessagePickupRepositoryClient.ts
+++ b/packages/client/src/MessagePickupRepositoryClient.ts
@@ -75,13 +75,14 @@ export class MessagePickupRepositoryClient implements MessagePickupRepository {
    * @param {JsonRpcParamsMessage} data - The data received via the 'messageReceive' event.
    *
    * @param {string} data.connectionId - The ID of the connection associated with the message.
-   * @param {QueuedMessage[]} data.message - An array of queued messages received.
+   * @param {string} data.message - queued messages received.
    * @param {string} [data.id] - (Optional) The identifier for the JSON-RPC message.
    *
    * @example
    * messageReceived((data: JsonRpcParamsMessage) => {
    *   console.log('ConnectionId:', data.connectionId);
-   *   console.log('Messages:', data.message);
+   *   const message = JSON.parse(data.message)
+   *   console.log('Messages:', message.id);
    * });
    */
   messageReceived(callback: (data: JsonRpcParamsMessage) => void): void {

--- a/packages/client/src/MessagePickupRepositoryClient.ts
+++ b/packages/client/src/MessagePickupRepositoryClient.ts
@@ -1,10 +1,10 @@
 import { Client } from 'rpc-websockets'
 import log from 'loglevel'
 import {
-  JsonRpcParamsMessage,
   RemoveAllMessagesOptions,
   ConnectionIdOptions,
   AddLiveSessionOptions,
+  MessageReceivedCallbackParams,
 } from './interfaces'
 import {
   AddMessageOptions,
@@ -20,7 +20,7 @@ log.setLevel('info')
 export class MessagePickupRepositoryClient implements MessagePickupRepository {
   private client?: Client
   private readonly logger = log
-  private messageReceivedCallback: ((data: JsonRpcParamsMessage) => void) | null = null
+  private messageReceivedCallback: ((data: MessageReceivedCallbackParams) => void) | null = null
 
   constructor(private readonly url: string) {}
 
@@ -41,7 +41,7 @@ export class MessagePickupRepositoryClient implements MessagePickupRepository {
 
         client.addListener('messageReceive', (data) => {
           if (this.messageReceivedCallback) {
-            this.messageReceivedCallback(data)
+            this.messageReceivedCallback(data as MessageReceivedCallbackParams)
           } else {
             this.logger.log('Received message event, but no callback is registered:', data)
           }
@@ -72,20 +72,20 @@ export class MessagePickupRepositoryClient implements MessagePickupRepository {
    * @param callback - The callback function to be invoked when 'messageReceive' is triggered.
    * The callback receives a `data` parameter of type `JsonRpcParamsMessage`, containing:
    *
-   * @param {JsonRpcParamsMessage} data - The data received via the 'messageReceive' event.
+   * @param {MessageReceivedCallbackParams} data - The data received via the 'messageReceive' event.
    *
    * @param {string} data.connectionId - The ID of the connection associated with the message.
-   * @param {string} data.message - queued messages received.
+   * @param {QueuedMessage[]} data.message - Array of queued messages received.
    * @param {string} [data.id] - (Optional) The identifier for the JSON-RPC message.
    *
    * @example
-   * messageReceived((data: JsonRpcParamsMessage) => {
+   * messageReceived((data: MessageReceivedCallbackParams) => {
+   *   const { connectionId, message } = data
    *   console.log('ConnectionId:', data.connectionId);
-   *   const message = JSON.parse(data.message)
-   *   console.log('Messages:', message.id);
+   *   console.log('Message:', message[0].id)
    * });
    */
-  messageReceived(callback: (data: JsonRpcParamsMessage) => void): void {
+  messageReceived(callback: (data: MessageReceivedCallbackParams) => void): void {
     this.messageReceivedCallback = callback
   }
 

--- a/packages/client/src/interfaces.ts
+++ b/packages/client/src/interfaces.ts
@@ -1,8 +1,4 @@
-export interface JsonRpcParamsMessage {
-  connectionId: string
-  message: string
-  id?: string
-}
+import { QueuedMessage } from '@credo-ts/core'
 
 export interface RemoveAllMessagesOptions {
   connectionId: string
@@ -16,4 +12,9 @@ export interface ConnectionIdOptions {
 export interface AddLiveSessionOptions {
   connectionId: string
   sessionId: string
+}
+
+export interface MessageReceivedCallbackParams {
+  connectionId: string
+  message: QueuedMessage[]
 }

--- a/packages/client/src/interfaces.ts
+++ b/packages/client/src/interfaces.ts
@@ -1,8 +1,6 @@
-import { QueuedMessage } from '@credo-ts/core'
-
 export interface JsonRpcParamsMessage {
   connectionId: string
-  message: QueuedMessage
+  message: string
   id?: string
 }
 

--- a/packages/server/src/websocket/websocket.service.spec.ts
+++ b/packages/server/src/websocket/websocket.service.spec.ts
@@ -114,17 +114,17 @@ describe('WebsocketService', () => {
     const connectionId = 'test-connection-id'
 
     // Mock Redis response
-    jest.spyOn(redisMock, 'llen').mockResolvedValue(5) // simula 5 mensajes en Redis
+    jest.spyOn(redisMock, 'llen').mockResolvedValue(5) // Simulate 5 messages in Redis.
 
     // Mock MongoDB countDocuments response
-    storeQueuedMessageMock.countDocuments = jest.fn().mockResolvedValue(3) // simula 3 mensajes en MongoDB
+    storeQueuedMessageMock.countDocuments = jest.fn().mockResolvedValue(3) //Simulate 3 messages in MongoDB.
 
     const result = await service.getAvailableMessageCount({
       connectionId: 'test-connection-id',
       id: '1',
     })
 
-    expect(result).toBe(8) // 5 mensajes de Redis + 3 mensajes de MongoDB
+    expect(result).toBe(8) // 5 messages from Redis + 3 messages from MongoDB
     expect(redisMock.llen).toHaveBeenCalledWith(`connectionId:${connectionId}:queuemessages`)
     expect(storeQueuedMessageMock.countDocuments).toHaveBeenCalledWith({ connectionId })
   })

--- a/packages/server/src/websocket/websocket.service.spec.ts
+++ b/packages/server/src/websocket/websocket.service.spec.ts
@@ -110,21 +110,23 @@ describe('WebsocketService', () => {
     expect(result[1].encryptedMessage).toBe('test-message-2') // Verifica por 'id'
   })
 
-  it('should getAvailableMessageCount of available messages from Redis', async () => {
-    // Mock Redis to return a predefined count of messages
-    jest.spyOn(redisMock, 'llen').mockResolvedValue(5)
+  it('should getAvailableMessageCount of available messages from Redis and MongoDB', async () => {
+    const connectionId = 'test-connection-id'
 
-    // Execute the getAvailableMessageCount method
+    // Mock Redis response
+    jest.spyOn(redisMock, 'llen').mockResolvedValue(5) // simula 5 mensajes en Redis
+
+    // Mock MongoDB countDocuments response
+    storeQueuedMessageMock.countDocuments = jest.fn().mockResolvedValue(3) // simula 3 mensajes en MongoDB
+
     const result = await service.getAvailableMessageCount({
       connectionId: 'test-connection-id',
       id: '1',
     })
 
-    // Verify that Redis was called with the correct key
-    expect(redisMock.llen).toHaveBeenCalledWith('connectionId:test-connection-id:queuemessages')
-
-    // Verify the returned count of available messages
-    expect(result).toBe(5)
+    expect(result).toBe(8) // 5 mensajes de Redis + 3 mensajes de MongoDB
+    expect(redisMock.llen).toHaveBeenCalledWith(`connectionId:${connectionId}:queuemessages`)
+    expect(storeQueuedMessageMock.countDocuments).toHaveBeenCalledWith({ connectionId })
   })
 
   it('should addmessage method to the queue and publish it to Redis', async () => {
@@ -214,7 +216,7 @@ describe('WebsocketService', () => {
     // Verify that messages were removed from MongoDB
     expect(storeQueuedMessageMock.deleteMany).toHaveBeenCalledWith({
       connectionId: removeMessagesDto.connectionId,
-      _id: { $in: removeMessagesDto.messageIds.map((id) => new Object(id)) },
+      messageId: { $in: removeMessagesDto.messageIds.map((id) => new Object(id)) },
     })
   })
 })

--- a/packages/server/src/websocket/websocket.service.ts
+++ b/packages/server/src/websocket/websocket.service.ts
@@ -191,11 +191,13 @@ export class WebsocketService {
       await this.redis.rpush(`connectionId:${connectionId}:queuemessages`, JSON.stringify(messageData))
 
       // test send message to publish channel connection id
-      const messagePublish = {
-        id: messageId,
-        receivedAt,
-        encryptedMessage: payload,
-      }
+      const messagePublish: QueuedMessage[] = [
+        {
+          id: messageId,
+          receivedAt,
+          encryptedMessage: payload,
+        },
+      ]
 
       this.logger.debug(`[addMessage] Message stored in Redis for connectionId ${connectionId}`)
 
@@ -396,7 +398,7 @@ export class WebsocketService {
         })
 
         // Handles messages received on the subscribed Redis channel
-        this.redisSubscriber.on('message', (channel: string, message: QueuedMessage[]) => {
+        this.redisSubscriber.on('message', (channel: string, message: string) => {
           if (channel === connectionId) {
             this.logger.log(`*** [redisSubscriber] Received message from ${channel}: ${message} **`)
 
@@ -405,7 +407,7 @@ export class WebsocketService {
               method: 'messageReceive',
               params: {
                 connectionId,
-                message,
+                message: JSON.parse(message),
                 id: dto.id,
               },
             }


### PR DESCRIPTION
1.Fix the message data type to string in the messageReceived function to ensure correct handling within the callback inside the client.

2. On the server, the getAvailableMessageCount method is fixed by adding the count of messages stored in persistence. Additionally, the key field for deletion is changed from _id to messageId.

