### PR TITLE
refactor: rename event listener callback method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,14 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Print release outputs for debugging
         continue-on-error: true
         run: |
           echo "Release outputs:"
           echo ${{ toJson(steps.release-please.outputs) }}
-        
- # Initiate release process if release was created
+
+  # Initiate release process if release was created
   release-client:
     if: contains(needs.release-please.outputs.paths_released, 'packages/client')
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  
+
   release-server:
     if: contains(needs.release-please.outputs.paths_released, 'packages/server')
     runs-on: ubuntu-latest
@@ -94,7 +94,7 @@ jobs:
     env:
       DH_USERNAME: ${{secrets.DOCKER_HUB_LOGIN}}
       DH_TOKEN: ${{secrets.DOCKER_HUB_PWD}}
-      IMAGE_NAME: 'message-pickup-repository'      
+      IMAGE_NAME: 'message-pickup-repository'
       IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'dev' || github.ref }}
     steps:
       - name: Checkout message-pickup-repository
@@ -115,9 +115,9 @@ jobs:
 
       - name: Build Docker image
         run: |
-            cp yarn.lock packages/server
-            cd packages/server
-            docker build -f Dockerfile -t $DH_USERNAME/$IMAGE_NAME:$IMAGE_TAG .
-  
+          cp yarn.lock packages/server
+          cd packages/server
+          docker build -f Dockerfile -t $DH_USERNAME/$IMAGE_NAME:$IMAGE_TAG .
+
       - name: Push to DockerHub
         run: docker push $DH_USERNAME/$IMAGE_NAME:$IMAGE_TAG

--- a/docs/message-pickup-repository-client.md
+++ b/docs/message-pickup-repository-client.md
@@ -9,7 +9,7 @@ The `MessagePickupRepositoryClient` is a client library designed to interact wit
 1. [Installation](#installation)
 2. [Available Methods](#available-methods)
    - [connect()](#connect)
-   - [messageReceived()](#messageReceived)
+   - [messagesReceived()](#messagesReceived)
    - [takeFromQueue()](#takeFromQueue)
    - [getAvailableMessageCount()](#getAvailableMessageCount)
    - [addMessage()](#addMessage)
@@ -40,9 +40,9 @@ Establishes a WebSocket connection to the server.
 
 ---
 
-### `messageReceived(callback)`
+### `messagesReceived(callback)`
 
-Registers a callback to handle `messageReceive` events from the WebSocket server. This method will be primarily used to receive new messages that are published by the server.
+Registers a callback to handle `messagesReceived` events from the WebSocket server. This method will be primarily used to receive new messages that are published by the server.
 
 - **Parameters**:
 
@@ -178,7 +178,7 @@ Disconnects from the WebSocket server.
 Here is a simple usage example:
 
 ```typescript
-import { MessagePickupRepositoryClient } from './MessagePickupRepositoryClient'
+import { MessagePickupRepositoryClient } from '@2060.io/message-pickup-repository-client'
 
 async function runClient() {
   const client = new MessagePickupRepositoryClient('ws://localhost:3500')
@@ -189,7 +189,7 @@ async function runClient() {
     console.log('Connected to the WebSocket server.')
 
     // Register message receive callback
-    client.messageReceived((data) => {
+    client.messagesReceived((data) => {
       console.log('Received message:', data)
     })
 

--- a/docs/message-pickup-repository-server.md
+++ b/docs/message-pickup-repository-server.md
@@ -113,7 +113,7 @@ To resolve synchronization across multiple instances the Message Pickup Reposito
 
 - Then a new message is received, the server sends a JSON-RPC response to the client with the new message data.
 
-- Once the server send JSON-RPC response, the client receives the notification with the message through its subscription to the `messageReceive` event. The client’s callback function is triggered with the message data.
+- Once the server send JSON-RPC response, the client receives the notification with the message through its subscription to the `messagesReceived` event. The client’s callback function is triggered with the message data.
 
 ---
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,21 +2,18 @@
 
 ## [0.0.4](https://github.com/2060-io/message-pickup-repository/compare/@2060.io/message-pickup-repository-client@v0.0.3...@2060.io/message-pickup-repository-client@v0.0.4) (2024-10-18)
 
-
 ### Bug Fixes
 
-* client git path ([#14](https://github.com/2060-io/message-pickup-repository/issues/14)) ([687a0be](https://github.com/2060-io/message-pickup-repository/commit/687a0be7bfa71e06619b63b8706c2f7b60d6ed4c))
+- client git path ([#14](https://github.com/2060-io/message-pickup-repository/issues/14)) ([687a0be](https://github.com/2060-io/message-pickup-repository/commit/687a0be7bfa71e06619b63b8706c2f7b60d6ed4c))
 
 ## [0.0.3](https://github.com/2060-io/message-pickup-repository/compare/@2060.io/message-pickup-repository-client@v0.0.2...@2060.io/message-pickup-repository-client@v0.0.3) (2024-10-18)
 
-
 ### Bug Fixes
 
-* client types and service methods into server ([#5](https://github.com/2060-io/message-pickup-repository/issues/5)) ([a3ba864](https://github.com/2060-io/message-pickup-repository/commit/a3ba864c9e1e22d29890722459443ad7d78330b9))
+- client types and service methods into server ([#5](https://github.com/2060-io/message-pickup-repository/issues/5)) ([a3ba864](https://github.com/2060-io/message-pickup-repository/commit/a3ba864c9e1e22d29890722459443ad7d78330b9))
 
 ## [0.0.2](https://github.com/2060-io/message-pickup-repository/compare/@2060.io/message-pickup-repository-client-v0.0.1...@2060.io/message-pickup-repository-client@v0.0.2) (2024-10-18)
 
-
 ### Features
 
-* :sparkles: initial setup to Message Pickup Repository gateway ([#2](https://github.com/2060-io/message-pickup-repository/issues/2)) ([bbf5f20](https://github.com/2060-io/message-pickup-repository/commit/bbf5f207ca63f95f1afe83e17523c23b39c6c841))
+- :sparkles: initial setup to Message Pickup Repository gateway ([#2](https://github.com/2060-io/message-pickup-repository/issues/2)) ([bbf5f20](https://github.com/2060-io/message-pickup-repository/commit/bbf5f207ca63f95f1afe83e17523c23b39c6c841))

--- a/packages/client/src/MessagePickupRepositoryClient.ts
+++ b/packages/client/src/MessagePickupRepositoryClient.ts
@@ -4,7 +4,7 @@ import {
   RemoveAllMessagesOptions,
   ConnectionIdOptions,
   AddLiveSessionOptions,
-  MessageReceivedCallbackParams,
+  MessagesReceivedCallbackParams,
 } from './interfaces'
 import {
   AddMessageOptions,
@@ -20,7 +20,7 @@ log.setLevel('info')
 export class MessagePickupRepositoryClient implements MessagePickupRepository {
   private client?: Client
   private readonly logger = log
-  private messageReceivedCallback: ((data: MessageReceivedCallbackParams) => void) | null = null
+  private messagesReceivedCallback: ((data: MessagesReceivedCallbackParams) => void) | null = null
 
   constructor(private readonly url: string) {}
 
@@ -37,11 +37,11 @@ export class MessagePickupRepositoryClient implements MessagePickupRepository {
       client.on('open', () => {
         this.logger.log(`Connected to WebSocket server ${client}`)
 
-        client.subscribe('messageReceive')
+        client.subscribe('messagesReceived')
 
-        client.addListener('messageReceive', (data) => {
-          if (this.messageReceivedCallback) {
-            this.messageReceivedCallback(data as MessageReceivedCallbackParams)
+        client.addListener('messagesReceived', (data) => {
+          if (this.messagesReceivedCallback) {
+            this.messagesReceivedCallback(data as MessagesReceivedCallbackParams)
           } else {
             this.logger.log('Received message event, but no callback is registered:', data)
           }
@@ -65,28 +65,28 @@ export class MessagePickupRepositoryClient implements MessagePickupRepository {
   }
 
   /**
-   * Register a callback function for the 'messageReceive' event.
-   * This function allows you to set up a listener for the 'messageReceive' event,
+   * Register a callback function for the 'messagesReceived' event.
+   * This function allows you to set up a listener for the 'messagesReceived' event,
    * which is triggered when a message is received via JSON-RPC.
    *
-   * @param callback - The callback function to be invoked when 'messageReceive' is triggered.
+   * @param callback - The callback function to be invoked when 'messagesReceived' is triggered.
    * The callback receives a `data` parameter of type `JsonRpcParamsMessage`, containing:
    *
-   * @param {MessageReceivedCallbackParams} data - The data received via the 'messageReceive' event.
+   * @param {MessagesReceivedCallbackParams} data - The data received via the 'messagesReceived' event.
    *
    * @param {string} data.connectionId - The ID of the connection associated with the message.
    * @param {QueuedMessage[]} data.message - Array of queued messages received.
    * @param {string} [data.id] - (Optional) The identifier for the JSON-RPC message.
    *
    * @example
-   * messageReceived((data: MessageReceivedCallbackParams) => {
+   * messagesReceived((data: MessageReceivedCallbackParams) => {
    *   const { connectionId, message } = data
    *   console.log('ConnectionId:', data.connectionId);
    *   console.log('Message:', message[0].id)
    * });
    */
-  messageReceived(callback: (data: MessageReceivedCallbackParams) => void): void {
-    this.messageReceivedCallback = callback
+  messagesReceived(callback: (data: MessagesReceivedCallbackParams) => void): void {
+    this.messagesReceivedCallback = callback
   }
 
   /**

--- a/packages/client/src/interfaces.ts
+++ b/packages/client/src/interfaces.ts
@@ -14,7 +14,7 @@ export interface AddLiveSessionOptions {
   sessionId: string
 }
 
-export interface MessageReceivedCallbackParams {
+export interface MessagesReceivedCallbackParams {
   connectionId: string
   message: QueuedMessage[]
 }

--- a/packages/client/src/interfaces.ts
+++ b/packages/client/src/interfaces.ts
@@ -16,5 +16,5 @@ export interface AddLiveSessionOptions {
 
 export interface MessagesReceivedCallbackParams {
   connectionId: string
-  message: QueuedMessage[]
+  messages: QueuedMessage[]
 }

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -2,21 +2,18 @@
 
 ## [0.0.4](https://github.com/2060-io/message-pickup-repository/compare/@2060.io/message-pickup-repository-server@v0.0.3...@2060.io/message-pickup-repository-server@v0.0.4) (2024-10-23)
 
-
 ### Bug Fixes
 
-* multiple subscriptions to messages received during addLiveSession  ([#17](https://github.com/2060-io/message-pickup-repository/issues/17)) ([37270a0](https://github.com/2060-io/message-pickup-repository/commit/37270a0b21ead05e5c2e2285d001bc8d030c26d4))
+- multiple subscriptions to messages received during addLiveSession ([#17](https://github.com/2060-io/message-pickup-repository/issues/17)) ([37270a0](https://github.com/2060-io/message-pickup-repository/commit/37270a0b21ead05e5c2e2285d001bc8d030c26d4))
 
 ## [0.0.3](https://github.com/2060-io/message-pickup-repository/compare/@2060.io/message-pickup-repository-server@v0.0.2...@2060.io/message-pickup-repository-server@v0.0.3) (2024-10-21)
 
-
 ### Bug Fixes
 
-* client types and service methods into server ([#5](https://github.com/2060-io/message-pickup-repository/issues/5)) ([a3ba864](https://github.com/2060-io/message-pickup-repository/commit/a3ba864c9e1e22d29890722459443ad7d78330b9))
+- client types and service methods into server ([#5](https://github.com/2060-io/message-pickup-repository/issues/5)) ([a3ba864](https://github.com/2060-io/message-pickup-repository/commit/a3ba864c9e1e22d29890722459443ad7d78330b9))
 
 ## [0.0.2](https://github.com/2060-io/message-pickup-repository/compare/@2060.io/message-pickup-repository-server-v0.0.1...@2060.io/message-pickup-repository-server@v0.0.2) (2024-10-18)
 
-
 ### Features
 
-* :sparkles: initial setup to Message Pickup Repository gateway ([#2](https://github.com/2060-io/message-pickup-repository/issues/2)) ([bbf5f20](https://github.com/2060-io/message-pickup-repository/commit/bbf5f207ca63f95f1afe83e17523c23b39c6c841))
+- :sparkles: initial setup to Message Pickup Repository gateway ([#2](https://github.com/2060-io/message-pickup-repository/issues/2)) ([bbf5f20](https://github.com/2060-io/message-pickup-repository/commit/bbf5f207ca63f95f1afe83e17523c23b39c6c841))

--- a/packages/server/src/websocket/interfaces/interfaces.ts
+++ b/packages/server/src/websocket/interfaces/interfaces.ts
@@ -2,12 +2,12 @@ import { QueuedMessage } from '@credo-ts/core'
 
 export interface JsonRpcParams {
   connectionId: string
-  message: QueuedMessage[]
+  messages: QueuedMessage[]
   id: string
 }
 
 export interface JsonRpcResponseSubscriber {
   jsonrpc: '2.0'
-  method: 'messageReceive'
+  method: 'messagesReceived'
   params: JsonRpcParams
 }

--- a/packages/server/src/websocket/websocket.gateway.ts
+++ b/packages/server/src/websocket/websocket.gateway.ts
@@ -62,7 +62,7 @@ export class WebsocketGateway implements OnModuleInit, OnModuleDestroy {
         port: WS_PORT,
       })
 
-      this.server.event('messageReceive')
+      this.server.event('messagesReceived')
       this.server.createError(500, 'Error initializing WebSocket server', {
         jsonrpc: '2.0',
         result: 'error',

--- a/packages/server/src/websocket/websocket.service.ts
+++ b/packages/server/src/websocket/websocket.service.ts
@@ -576,7 +576,7 @@ export class WebsocketService {
    * @param {string} socket_id - The unique identifier of the WebSocket client to which the message will be sent.
    * @param {JsonRpcResponseSubscriber} message - The message to send, including:
    *   @property {string} jsonrpc - The JSON-RPC version, always '2.0'.
-   *   @property {string} method - The method being invoked, in this case, 'messageReceive'.
+   *   @property {string} method - The method being invoked, in this case, 'messagesReceived'.
    *   @property {Object} params - An object containing:
    *     @property {string} connectionId - The ID of the connection associated with the message.
    *     @property {QueuedMessage[]} message - An array of messages to be sent.
@@ -680,10 +680,10 @@ export class WebsocketService {
       // Parse and process the received message, and construct the JSON-RPC response
       const jsonRpcResponse: JsonRpcResponseSubscriber = {
         jsonrpc: '2.0',
-        method: 'messageReceive',
+        method: 'messagesReceived',
         params: {
           connectionId: channel, // The channel is treated as the connectionId
-          message: JSON.parse(message), // Parse the message to ensure it's valid JSON
+          messages: JSON.parse(message), // Parse the message to ensure it's valid JSON
           id: '',
         },
       }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,7 +6,7 @@
   },
   "compilerOptions": {
     "baseUrl": ".",
-    "types": ["node", "jest"],
+    "types": ["node", "jest"]
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
The messageReceived event is renamed to messagesReceived as requested.