### PR TITLE
Feat: Handling messages limit based on messages size

### DIFF
--- a/docs/message-pickup-repository-client.md
+++ b/docs/message-pickup-repository-client.md
@@ -63,6 +63,7 @@ Retrieves messages from the queue.
   - `connectionId: string`: ID of the connection.
   - `recipientDid?: string`: Optional DID of the recipient.
   - `limit?: number`: Optional limit on the number of messages.
+  - `limitBytes?: number`: Optional byte size limit for retrieving messages
   - `deleteMessages?: boolean`: Whether to delete the messages after retrieval.
 
 - **Returns**: `Promise<QueuedMessage[]>`

--- a/packages/client/src/MessagePickupRepositoryClient.ts
+++ b/packages/client/src/MessagePickupRepositoryClient.ts
@@ -21,11 +21,13 @@ export class MessagePickupRepositoryClient implements MessagePickupRepository {
   private client?: Client
   private readonly logger = log
   private messagesReceivedCallback: ((data: MessagesReceivedCallbackParams) => void) | null = null
+  private readonly url: string
+  private readonly maxReceiveBytes?: number
 
-  constructor(
-    private readonly url: string,
-    private readonly maxReceiveBytes?: number,
-  ) {}
+  constructor(options: { url: string; maxReceiveBytes?: number }) {
+    this.url = options.url
+    this.maxReceiveBytes = options.maxReceiveBytes
+  }
 
   /**
    * Connect to the WebSocket server.

--- a/packages/client/src/interfaces.ts
+++ b/packages/client/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { QueuedMessage } from '@credo-ts/core'
+import { QueuedMessage, TakeFromQueueOptions } from '@credo-ts/core'
 
 export interface RemoveAllMessagesOptions {
   connectionId: string
@@ -17,4 +17,8 @@ export interface AddLiveSessionOptions {
 export interface MessagesReceivedCallbackParams {
   connectionId: string
   messages: QueuedMessage[]
+}
+
+export interface ExtendedTakeFromQueueOptions extends TakeFromQueueOptions {
+  limitBytes?: number
 }

--- a/packages/server/src/config/app.config.ts
+++ b/packages/server/src/config/app.config.ts
@@ -65,4 +65,11 @@ export default registerAs('appConfig', () => ({
    *Allows set threshold time to execute messagePersist module on milisecond
    */
   thresholdTimestamp: parseInt(process.env.THRESHOLD_TIMESTAMP) || 60000,
+
+  /**
+   * The maximum total message size in bytes.
+   * Defaults to 1 MB (1 * 1024 * 1024 bytes) if MAX_TOTAL_MESSAGE_SIZE_MB is not set in the environment variables.
+   * @type {number}
+   */
+  maxMessageSizeBytes: (parseInt(process.env.MAX_MESSAGE_SIZE_BYTES, 10) || 1) * 1024 * 1024,
 }))

--- a/packages/server/src/config/app.config.ts
+++ b/packages/server/src/config/app.config.ts
@@ -65,11 +65,4 @@ export default registerAs('appConfig', () => ({
    *Allows set threshold time to execute messagePersist module on milisecond
    */
   thresholdTimestamp: parseInt(process.env.THRESHOLD_TIMESTAMP) || 60000,
-
-  /**
-   * The maximum total message size in bytes.
-   * Defaults to 1 MB (1 * 1024 * 1024 bytes) if MAX_TOTAL_MESSAGE_SIZE_MB is not set in the environment variables.
-   * @type {number}
-   */
-  maxMessageSizeBytes: (parseInt(process.env.MAX_MESSAGE_SIZE_BYTES, 10) || 1) * 1024 * 1024,
 }))

--- a/packages/server/src/websocket/dto/messagerepository-websocket.dto.ts
+++ b/packages/server/src/websocket/dto/messagerepository-websocket.dto.ts
@@ -29,7 +29,7 @@ export class TakeFromQueueDto {
 
   @IsOptional()
   @IsInt()
-  limitSize?: number
+  limitBytes?: number
 
   @IsOptional()
   @IsBoolean()

--- a/packages/server/src/websocket/dto/messagerepository-websocket.dto.ts
+++ b/packages/server/src/websocket/dto/messagerepository-websocket.dto.ts
@@ -25,7 +25,11 @@ export class TakeFromQueueDto {
 
   @IsOptional()
   @IsInt()
-  limit: number
+  limit?: number
+
+  @IsOptional()
+  @IsInt()
+  limitSize?: number
 
   @IsOptional()
   @IsBoolean()

--- a/packages/server/src/websocket/schemas/StoreQueuedMessage.ts
+++ b/packages/server/src/websocket/schemas/StoreQueuedMessage.ts
@@ -36,7 +36,7 @@ export class StoreQueuedMessage extends Document {
    * @type {number}
    */
   @Prop()
-  encryptedMessageSize?: number
+  encryptedMessageByteCount?: number
 
   /**
    * The recipient keys (DIDs or other identifiers) associated with the message.

--- a/packages/server/src/websocket/schemas/StoreQueuedMessage.ts
+++ b/packages/server/src/websocket/schemas/StoreQueuedMessage.ts
@@ -32,6 +32,13 @@ export class StoreQueuedMessage extends Document {
   encryptedMessage: EncryptedMessage
 
   /**
+   * The size Encrypted Message store in collection
+   * @type {number}
+   */
+  @Prop()
+  encryptedMessageSize?: number
+
+  /**
    * The recipient keys (DIDs or other identifiers) associated with the message.
    * @type {string[]}
    */
@@ -44,6 +51,7 @@ export class StoreQueuedMessage extends Document {
    */
   @Prop()
   state?: string
+
   /**
    * The timestamp when the message was created.
    * Mongoose automatically creates this field when `timestamps: true` is set in the schema.

--- a/packages/server/src/websocket/services/MessagePersister.ts
+++ b/packages/server/src/websocket/services/MessagePersister.ts
@@ -62,6 +62,7 @@ export class MessagePersister {
               connectionId: message.connectionId,
               recipientKeys: message.recipientDids,
               encryptedMessage: message.encryptedMessage,
+              encryptedMessageSize: message.encryptedMessageSize,
               state: message.state,
               createdAt: new Date(message.receivedAt),
             })

--- a/packages/server/src/websocket/websocket.service.spec.ts
+++ b/packages/server/src/websocket/websocket.service.spec.ts
@@ -71,7 +71,46 @@ describe('WebsocketService', () => {
     expect(service).toBeDefined()
   })
 
-  it('should takeFromQueue (Redis and MongoDB)', async () => {
+  it('should takeFromQueue (Redis and MongoDB) with size message', async () => {
+    // Mock configuration for Redis
+    jest.spyOn(redisMock, 'lrange').mockResolvedValue([
+      JSON.stringify({
+        id: '1', // Usar 'id' en lugar de 'messageId'
+        encryptedMessage: 'test-message-2',
+        receivedAt: new Date().toISOString(),
+      }),
+    ])
+
+    // Mock configuration for MongoDB
+    storeQueuedMessageMock.exec.mockResolvedValue([
+      {
+        id: '2', // MongoDB usa _id por defecto
+        encryptedMessage: 'test-message-1',
+        createdAt: new Date(),
+      },
+    ])
+
+    // Execute the takeFromQueue method
+    const result = await service.takeFromQueue({
+      connectionId: 'test-connection-id',
+      id: '',
+      limitSize: 1,
+    })
+
+    // Verify that Redis and MongoDB calls were made
+    expect(redisMock.lrange).toHaveBeenCalledWith('connectionId:test-connection-id:queuemessages', 0, -1)
+    expect(storeQueuedMessageMock.find).toHaveBeenCalledWith({
+      $or: [{ connectionId: 'test-connection-id' }, { recipientKeys: undefined }],
+      state: 'pending',
+    })
+
+    // Verify the combined result from Redis and MongoDB
+    expect(result).toHaveLength(2)
+    expect(result[0].encryptedMessage).toBe('test-message-1') // Verifica por 'id'
+    expect(result[1].encryptedMessage).toBe('test-message-2') // Verifica por 'id'
+  })
+
+  it('should takeFromQueue (Redis and MongoDB) with limit message', async () => {
     // Mock configuration for Redis
     jest.spyOn(redisMock, 'lrange').mockResolvedValue([
       JSON.stringify({

--- a/packages/server/src/websocket/websocket.service.spec.ts
+++ b/packages/server/src/websocket/websocket.service.spec.ts
@@ -94,7 +94,7 @@ describe('WebsocketService', () => {
     const result = await service.takeFromQueue({
       connectionId: 'test-connection-id',
       id: '',
-      limitSize: 1,
+      limitBytes: 1000000,
     })
 
     // Verify that Redis and MongoDB calls were made

--- a/packages/server/src/websocket/websocket.service.spec.ts
+++ b/packages/server/src/websocket/websocket.service.spec.ts
@@ -76,7 +76,7 @@ describe('WebsocketService', () => {
     jest.spyOn(redisMock, 'lrange').mockResolvedValue([
       JSON.stringify({
         id: '1', // Usar 'id' en lugar de 'messageId'
-        encryptedMessage: 'test-message-1',
+        encryptedMessage: 'test-message-2',
         receivedAt: new Date().toISOString(),
       }),
     ])
@@ -85,7 +85,7 @@ describe('WebsocketService', () => {
     storeQueuedMessageMock.exec.mockResolvedValue([
       {
         id: '2', // MongoDB usa _id por defecto
-        encryptedMessage: 'test-message-2',
+        encryptedMessage: 'test-message-1',
         createdAt: new Date(),
       },
     ])

--- a/packages/server/src/websocket/websocket.service.ts
+++ b/packages/server/src/websocket/websocket.service.ts
@@ -727,7 +727,7 @@ export class WebsocketService {
    * @param {TakeFromQueueDto} dto - Data transfer object containing query parameters.
    * @returns {Promise<QueuedMessage[]>} - A promise that resolves to an array of queued messages.
    */
-  private async takeMessagesWithSize(dto: TakeFromQueueDto): Promise<QueuedMessage[]> {
+  private async takeMessagesWithByteCountLimit(dto: TakeFromQueueDto): Promise<QueuedMessage[]> {
     const { connectionId, recipientDid, limitSize } = dto
     const maxMessageSizeBytes = limitSize * 1024 * 1024
     let currentSize = 0

--- a/packages/server/src/websocket/websocket.service.ts
+++ b/packages/server/src/websocket/websocket.service.ts
@@ -660,7 +660,7 @@ export class WebsocketService {
    * @param {TakeFromQueueDto} dto - Data transfer object containing query parameters.
    * @returns {Promise<QueuedMessage[]>} - A promise that resolves to an array of queued messages.
    */
-  private async takeMessagesWithLimit(dto: TakeFromQueueDto): Promise<QueuedMessage[]> {
+  private async takeMessagesWithMessageCountLimit(dto: TakeFromQueueDto): Promise<QueuedMessage[]> {
     const { connectionId, limit, recipientDid } = dto
 
     this.logger.debug('[takeMessagesWithLimit] Method called with DTO:', dto)


### PR DESCRIPTION
The addMessage method implements the calculation of message size only (payload) in bytes for storage. Additionally, a constraint is implemented in the takeFromQueue function to return the number of messages that occupy up to 1 MB by default, which can also be configurable.