### PR TITLE
fix: HttpService Injection in WebsocketService for Push Notification Sending

### DIFF
--- a/packages/server/src/websocket/websocket.gateway.ts
+++ b/packages/server/src/websocket/websocket.gateway.ts
@@ -68,7 +68,7 @@ export class WebsocketGateway implements OnModuleInit, OnModuleDestroy {
         result: 'error',
         id: 1,
       })
-      this.logger.error(`WebSocket server listening on port ${WS_PORT}`)
+      this.logger.log(`WebSocket server listening on port ${WS_PORT}`)
     } catch (error) {
       this.logger.error('Error during WebSocket server initialization', error.stack)
       throw error

--- a/packages/server/src/websocket/websocket.module.ts
+++ b/packages/server/src/websocket/websocket.module.ts
@@ -5,6 +5,7 @@ import { MongooseModule } from '@nestjs/mongoose'
 import { StoreQueuedMessageSchema, StoreQueuedMessage } from './schemas/StoreQueuedMessage'
 import { StoreLiveSessionSchema, StoreLiveSession } from './schemas/StoreLiveSession'
 import { MessagePersister } from './services/MessagePersister'
+import { HttpModule } from '@nestjs/axios'
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { MessagePersister } from './services/MessagePersister'
       { name: StoreQueuedMessage.name, schema: StoreQueuedMessageSchema },
       { name: StoreLiveSession.name, schema: StoreLiveSessionSchema },
     ]),
+    HttpModule,
   ],
   providers: [WebsocketGateway, WebsocketService, MessagePersister],
 })

--- a/packages/server/test/WebsocketTestModule.ts
+++ b/packages/server/test/WebsocketTestModule.ts
@@ -4,6 +4,7 @@ import { WebsocketGateway } from '../src/websocket/websocket.gateway'
 import { MongooseModule } from '@nestjs/mongoose'
 import { StoreQueuedMessageSchema, StoreQueuedMessage } from '../src/websocket/schemas/StoreQueuedMessage'
 import { StoreLiveSessionSchema, StoreLiveSession } from '../src/websocket/schemas/StoreLiveSession'
+import { HttpModule } from '@nestjs/axios'
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { StoreLiveSessionSchema, StoreLiveSession } from '../src/websocket/schem
       { name: StoreQueuedMessage.name, schema: StoreQueuedMessageSchema },
       { name: StoreLiveSession.name, schema: StoreLiveSessionSchema },
     ]),
+    HttpModule,
   ],
   providers: [WebsocketGateway, WebsocketService],
 })


### PR DESCRIPTION
This PR resolves the HttpService undefined issue in WebsocketService by correctly injecting it in the constructor. Additionally, it adds validations in the sendPushNotification method to ensure:

- pushNotificationUrl is defined in the configuration.

- token and messageId are valid before attempting to send.

- fix logger initServer method 