### PR TITLE
fix: connection add database postgres as default

### DIFF
--- a/packages/postgres/src/config/dbCollections.ts
+++ b/packages/postgres/src/config/dbCollections.ts
@@ -28,3 +28,26 @@ CREATE TABLE IF NOT EXISTS ${liveSessionTableName} (
 export const messageTableIndex = `CREATE INDEX IF NOT EXISTS "${messagesTableName}_connection_id_idx" ON "${messagesTableName}" (connection_id);`
 
 export const liveSessionTableIndex = `CREATE INDEX IF NOT EXISTS "${liveSessionTableName}_connection_id_idx" ON "${liveSessionTableName}" USING btree (connection_id);`
+
+export const messagesTableMigration = `
+    INSERT INTO queued_message (id, connection_id, recipient_dids, encrypted_message, state, created_at)
+    SELECT
+      gen_random_uuid(),  -- nuevo id
+      connectionid,
+      recipientKeys,
+      encryptedMessage,
+      'pending',
+      created_at
+    FROM queuedmessage
+  `
+
+export const liveSessionTableMigration = `
+    INSERT INTO live_session (session_id, connection_id, protocol_version, instance, created_at)
+    SELECT
+      sessionid,
+      connectionid,
+      protocolVersion,
+      instance,
+      created_at
+    FROM livesession
+  `


### PR DESCRIPTION
1. To solve a recurrence issue that was occurring when both databases did not exist and needed to be created, a direct connection to the ´postgres´ database has been added in the ´buildPgDatabase´ function.

1. Additionally, extra checks have been added for the creation of the message_state type and a routine for the automatic migration of data from the old database structure to the new one in this version.