### PR TITLE
fix: Correct field name 'encrypted_message' in return mapping takeFromQueue

### DIFF
--- a/packages/postgres/src/PostgresMessagePickupRepository.ts
+++ b/packages/postgres/src/PostgresMessagePickupRepository.ts
@@ -172,7 +172,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
 
         return result.rows.map((message) => ({
           id: message.id,
-          encryptedMessage: message.encryptedmessage,
+          encryptedMessage: message.encrypted_message,
           state: message.state,
         }))
       }


### PR DESCRIPTION
The field was incorrectly referenced as 'encryptedmessage' in the return object, causing the agent to build attachments with undefined content. 

This change ensures the correct 'encrypted_message' field is used from the database result.

The issue was reproduced locally and has been properly tested to confirm the fix.