### PR TITLE
fix: Fix all references encryptedmessages column database legacy schema

### DIFF
--- a/packages/postgres/src/PostgresMessagePickupRepository.ts
+++ b/packages/postgres/src/PostgresMessagePickupRepository.ts
@@ -204,7 +204,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
       // Return the messages as QueuedMessage objects
       return result.rows.map((message) => ({
         id: message.id,
-        encryptedMessage: message.encryptedmessage,
+        encryptedMessage: message.encrypted_message,
         state: 'sending',
       }))
     } catch (error) {
@@ -296,7 +296,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
           id: messageRecord.id,
           connectionId,
           recipientDids,
-          encryptedMessage: messageRecord.encryptedmessage,
+          encryptedMessage: messageRecord.encrypted_message,
           receivedAt: messageRecord.created_at,
           state,
         },


### PR DESCRIPTION
Review and fix all `encryptedmessages` references from the legacy Message Pickup Repository PG schema 