### PR TITLE
feat: Add maxReceiveBytes filter to takeFromQueue

### DIFF
--- a/packages/postgres/src/PostgresMessagePickupRepository.ts
+++ b/packages/postgres/src/PostgresMessagePickupRepository.ts
@@ -39,15 +39,17 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
   private postgresPassword: string
   private postgresHost: string
   private postgresDatabaseName: string
+  private maxReceiveBytes?: number
 
   public constructor(options: PostgresMessagePickupRepositoryConfig) {
-    const { logger, postgresUser, postgresPassword, postgresHost, postgresDatabaseName } = options
+    const { logger, postgresUser, postgresPassword, postgresHost, postgresDatabaseName, maxReceiveBytes } = options
 
     this.logger = logger
     this.postgresUser = postgresUser
     this.postgresPassword = postgresPassword
     this.postgresHost = postgresHost
     this.postgresDatabaseName = postgresDatabaseName || 'messagepickuprepository'
+    this.maxReceiveBytes = maxReceiveBytes
 
     // Initialize instanceName
     this.instanceName = `${os.hostname()}-${process.pid}-${randomUUID()}`
@@ -148,20 +150,38 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
    */
   public async takeFromQueue(options: TakeFromQueueOptions): Promise<QueuedMessage[]> {
     const { connectionId, limit, deleteMessages, recipientDid } = options
-    this.logger?.info(`[takeFromQueue] Initializing method for ConnectionId: ${connectionId}, Limit: ${limit}`)
+    const limitBytes = typeof this.maxReceiveBytes === 'number'
+
+    this.logger?.info(
+      `[takeFromQueue] Fetching for ConnectionId: ${connectionId}. Mode: ${limitBytes ? `maxReceiveBytes=${this.maxReceiveBytes}` : `limit=${limit}`}`,
+    )
 
     try {
-      // If deleteMessages is true, just fetch messages without updating their state
+      const paramsBase = [connectionId, recipientDid]
+
       if (deleteMessages) {
-        const query = `
-        SELECT id, encrypted_message, state 
-        FROM queued_message 
-        WHERE (connection_id = $1 OR $2 = ANY (recipient_dids)) AND state = 'pending' 
-        ORDER BY created_at 
-        LIMIT $3
-      `
-        const params = [connectionId, recipientDid, limit ?? 0]
-        const result = await this.messagesCollection?.query(query, params)
+        const query = limitBytes
+          ? `
+          SELECT id, encrypted_message, state
+          FROM queued_message
+          WHERE (connection_id = $1 OR $2 = ANY (recipient_dids))
+            AND state = 'pending'
+            AND encrypted_message_byte_count <= $3
+          ORDER BY created_at
+        `
+          : `
+          SELECT id, encrypted_message, state
+          FROM queued_message
+          WHERE (connection_id = $1 OR $2 = ANY (recipient_dids))
+            AND state = 'pending'
+          ORDER BY created_at
+          LIMIT $3
+        `
+
+        const result = await this.messagesCollection?.query(query, [
+          ...paramsBase,
+          limitBytes ? this.maxReceiveBytes : (limit ?? 0),
+        ])
 
         if (!result || result.rows.length === 0) {
           this.logger?.debug(`[takeFromQueue] No messages found for ConnectionId: ${connectionId}`)
@@ -175,22 +195,39 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
         }))
       }
 
-      // Use UPDATE and RETURNING to fetch and update messages in one step
-      const query = `
-      UPDATE queued_message
-      SET state = 'sending'
-      WHERE id IN (
-        SELECT id 
-        FROM queued_message 
-        WHERE (connection_id = $1 OR $2 = ANY (recipient_dids)) 
-        AND state = 'pending' 
-        ORDER BY created_at 
-        LIMIT $3
-      )
-      RETURNING id, encrypted_message, state;
-    `
-      const params = [connectionId, recipientDid, limit ?? 0]
-      const result = await this.messagesCollection?.query(query, params)
+      // If not deleting, update state to 'sending'
+      const query = limitBytes
+        ? `
+        UPDATE queued_message
+        SET state = 'sending'
+        WHERE id IN (
+          SELECT id
+          FROM queued_message
+          WHERE (connection_id = $1 OR $2 = ANY (recipient_dids))
+            AND state = 'pending'
+            AND encrypted_message_byte_count <= $3
+          ORDER BY created_at
+        )
+        RETURNING id, encrypted_message, state
+      `
+        : `
+        UPDATE queued_message
+        SET state = 'sending'
+        WHERE id IN (
+          SELECT id
+          FROM queued_message
+          WHERE (connection_id = $1 OR $2 = ANY (recipient_dids))
+            AND state = 'pending'
+          ORDER BY created_at
+          LIMIT $3
+        )
+        RETURNING id, encrypted_message, state
+      `
+
+      const result = await this.messagesCollection?.query(query, [
+        ...paramsBase,
+        limitBytes ? this.maxReceiveBytes : (limit ?? 0),
+      ])
 
       if (!result || result.rows.length === 0) {
         this.logger?.debug(`[takeFromQueue] No messages updated for ConnectionId: ${connectionId}`)
@@ -199,7 +236,6 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
 
       this.logger?.debug(`[takeFromQueue] ${result.rows.length} messages updated to "sending" state.`)
 
-      // Return the messages as QueuedMessage objects
       return result.rows.map((message) => ({
         id: message.id,
         encryptedMessage: message.encrypted_message,
@@ -267,19 +303,28 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
     }
 
     try {
+      // Calculate the size in bytes of the encrypted message to add database
+      const encryptedMessageByteCount = Buffer.byteLength(JSON.stringify(payload), 'utf8')
+
       // Retrieve local live session details
       const localLiveSession = await this.findLocalLiveSession(connectionId)
 
       // Insert message into database
       const query = `
-        INSERT INTO queued_message(connection_id, recipient_dids, encrypted_message, state) 
-        VALUES($1, $2, $3, $4) 
+        INSERT INTO queued_message(connection_id, recipient_dids, encrypted_message, state,encrypted_message_byte_count) 
+        VALUES($1, $2, $3, $4, $5)
         RETURNING id, created_at, encrypted_message
       `
 
       const state = localLiveSession ? 'sending' : 'pending'
 
-      const result = await this.messagesCollection?.query(query, [connectionId, recipientDids, payload, state])
+      const result = await this.messagesCollection?.query(query, [
+        connectionId,
+        recipientDids,
+        payload,
+        state,
+        encryptedMessageByteCount,
+      ])
 
       const messageRecord = result?.rows[0]
 

--- a/packages/postgres/src/interfaces.ts
+++ b/packages/postgres/src/interfaces.ts
@@ -7,6 +7,7 @@ export interface PostgresMessagePickupRepositoryConfig {
   postgresPassword: string
   postgresHost: string
   postgresDatabaseName?: string
+  maxReceiveBytes?: number
 }
 
 export const MessageQueuedEventType: string = 'MessagePickupRepositoryMessageQueued'

--- a/packages/postgres/src/migrations/003-add-maxReceiveBytes.sql
+++ b/packages/postgres/src/migrations/003-add-maxReceiveBytes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE queued_message
+ADD COLUMN IF NOT EXISTS encrypted_message_byte_count INTEGER;


### PR DESCRIPTION
This PR introduces a new capability to filter message retrieval by size in the PostgresMessagePickupRepository. This allows services to avoid loading large payloads beyond a configurable byte threshold.

## What's New

- Adds maxReceiveBytes to PostgresMessagePickupRepositoryConfig
- Adds new DB column: encrypted_message_byte_count
- Includes database migration script for column addition
- Enhances addMessage to calculate and store message size
- Updates takeFromQueue to support size-based filtering