### PR TITLE
feat: redefine receivedAt with system time when inserting messages

### DIFF
--- a/packages/postgres/src/PostgresMessagePickupRepository.ts
+++ b/packages/postgres/src/PostgresMessagePickupRepository.ts
@@ -277,7 +277,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
       // Insert message into database
       const query = `
         INSERT INTO queued_message(connection_id, recipient_dids, encrypted_message, state, created_at) 
-        VALUES($1, $2, $3, $4,$5) 
+        VALUES($1, $2, $3, $4, $5) 
         RETURNING id
       `
 


### PR DESCRIPTION
## What’s changed
- We now redefine `receivedAt` in the application using `new Date()`
- That timestamp is inserted into the `created_at` column of `queued_message`
- Use the new `receivedAt` in the `emitMessageQueuedEvent` 
- The debug log now explicitly shows the system timestamp